### PR TITLE
Fix invalid expression-bodied method in test

### DIFF
--- a/MakeInterface.Tests/InterfaceGeneratorTests.cs
+++ b/MakeInterface.Tests/InterfaceGeneratorTests.cs
@@ -312,7 +312,7 @@ namespace MakeInterface.Tests
     [GenerateInterface]
     public class Class
     {
-        public string Get() => return "foo";
+        public string Get() => "foo";
     }
 }
 """;


### PR DESCRIPTION
## Summary
- fix expression-bodied method syntax in Method_Expression_Body test

## Testing
- `dotnet test MakeInterface.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68428cc273b0832e83567349ce2bfffb