### PR TITLE
Add prerelease publishing workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,30 +1,49 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: .NET
 
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore --configuration Release
-    - name: Test
-      run: dotnet test --no-build --verbosity normal --configuration Release
-    - name: Push Package to NuGet.org
-      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Determine package version
+        id: version
+        shell: bash
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0.1.0-ci.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release /p:Version=${{ steps.version.outputs.version }}
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal --configuration Release
+
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+
+      - name: Publish prerelease to GitHub Packages
+        if: github.event_name == 'push' && github.ref_type == 'branch'
+        run: dotnet nuget push ./artifacts/*.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+
+      - name: Publish release to NuGet.org
+        if: github.ref_type == 'tag'
+        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/readme.md
+++ b/readme.md
@@ -40,3 +40,6 @@ The required `GenerateInterface` attribute is automatically provided by the sour
 
 ## License
 MIT
+## Release process
+- Pushes to the `master` branch publish prerelease packages to GitHub Packages using versions like `0.1.0-ci.<run number>`.
+- Tagging the repository with `v<version>` automatically publishes that version to NuGet.org if `NUGET_API_KEY` is configured.


### PR DESCRIPTION
## Summary
- create CI workflow for prerelease builds and NuGet releases
- document release steps

## Testing
- `dotnet test --no-build --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_68429c5c3528832e826b34b52b7e8170