### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,12 +38,12 @@ jobs:
         run: dotnet test --no-build --verbosity normal --configuration Release
 
       - name: Pack
-        run: dotnet pack --no-build --configuration Release /p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+        run: dotnet pack MakeInterface.Generator/MakeInterface.Generator.csproj --no-build --configuration Release /p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: Publish prerelease to GitHub Packages
         if: github.event_name == 'push' && github.ref_type == 'branch'
-        run: dotnet nuget push ./artifacts/*.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+        run: dotnet nuget push ./artifacts/MakeInterface.Generator.${{ steps.version.outputs.version }}.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
       - name: Publish release to NuGet.org
         if: github.ref_type == 'tag'
-        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        run: dotnet nuget push ./artifacts/MakeInterface.Generator.${{ steps.version.outputs.version }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/MakeInterface.Generator/MakeInterface.Generator.csproj
+++ b/MakeInterface.Generator/MakeInterface.Generator.csproj
@@ -12,7 +12,7 @@
 		<OutputType>library</OutputType>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>MakeInterface.Generator</PackageId>
-		<Version>1.0.0-preview2</Version>
+                <Version>1.0.0</Version>
 		<Authors>Frederik Tegnander</Authors>
 		<Company>COWI</Company>
 		<PackageTags>Interfaces;SourceGenerator;MakeInterface</PackageTags>


### PR DESCRIPTION
## Summary
- release MakeInterface.Generator v1.0.0
- update CI workflow to reference package path explicitly

## Testing
- `dotnet test --no-build --verbosity normal --configuration Release`
- `dotnet test --no-build --configuration Release --logger:"console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_6842d6dbd3b4832eb00df118d0564322